### PR TITLE
upgrade to ak v2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,11 +10,10 @@ dependencies:
   - tqdm>=4.64.1
   - fsspec>=2022.8.2
   - llvmlite>=0.38.1
-  - pip>=22.2.2
-  - awkward>=1.9
   - pandas>=1.4.4
   - tqdm>=4.64.1
   - matplotlib>=3.6.2
   - pip>=22.2.2
   - pip:
+    - awkward>=2.0.0
     - git+https://github.com/Cloud-Drift/clouddrift.git


### PR DESCRIPTION
Put back awkward in the pip section of the env.

The binder devs told me to limit the pip installation to avoid environement problem, so as soon as the conda awkward v2 is up, we should move it back.